### PR TITLE
Build for server rendering in node

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "npm run lint && npm run unit",
     "unit": "mocha --reporter nyan --require babel-register --require ./tools/test-globals --recursive 'src/**/*.test.js'",
     "unit:watch": "npm run unit -- --watch",
-    "serverside": "webpack && babel-node src/server.js"
+    "serverside": "webpack && webpack --config webpack.config.node.babel.js && node public/server.js"
   },
   "dependencies": {
     "babel-cli": "^6.4.5",
@@ -55,6 +55,7 @@
     "eslint-plugin-react": "^3.16.1",
     "mocha": "^2.4.4",
     "parallelshell": "^2.0.0",
+    "raw-loader": "^0.5.1",
     "react-hot-loader": "^1.3.0",
     "webpack-dev-server": "^1.14.1"
   },

--- a/webpack.config.node.babel.js
+++ b/webpack.config.node.babel.js
@@ -1,0 +1,60 @@
+import path from 'path';
+import webpack from 'webpack';
+import nib from 'nib';
+
+const isProduction = process.env.NODE_ENV === 'production';
+const isDevelopment = !isProduction;
+const getPath = (...args) => path.join(__dirname, ...args);
+// Remove any falsy values from the input args or array. Return an array.
+const getArray = (...args) => [].concat(...args).filter(Boolean);
+
+export default {
+  context: getPath('./'),
+  entry: './src/server',
+  target: 'node',
+  output: {
+    path: getPath('public'),
+    filename: 'server.js',
+    pathinfo: isDevelopment,
+    publicPath: '/public/',
+  },
+  resolve: {
+    extensions: ['', '.js', '.jsx', '.styl'],
+  },
+  plugins: getArray([
+    new webpack.optimize.OccurenceOrderPlugin(),
+    isProduction && new webpack.optimize.DedupePlugin(),
+    isProduction && new webpack.optimize.UglifyJsPlugin({minimize: true, sourceMap: true}),
+    isDevelopment && new webpack.NoErrorsPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+      },
+    }),
+  ]),
+  stylus: {
+    use: [nib()],
+    import: ['~nib/lib/nib/index.styl'],
+  },
+  module: {
+    preLoaders: [
+      {
+        test: /\.jsx?$/,
+        loaders: getArray(isDevelopment && 'eslint-loader'),
+        include: getPath('src'),
+      },
+    ],
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        loaders: getArray(isDevelopment && 'react-hot', 'babel-loader'),
+        include: getPath('src'),
+      },
+      {
+        test: /\.styl$/,
+        loaders: ['raw-loader', 'css-loader', 'stylus-loader'],
+        include: getPath('src'),
+      },
+    ],
+  },
+};


### PR DESCRIPTION
- Build a copy for node that targeting node will exclude node's apis so
  that they are loaded normally by node, especially if they are binary.
  Other packages can be excluded with the externals options.
- User raw-loader for style, as style-loader is written for browsers

A separate loader would be needed that could upstream the style so it
can be shipped with the html. Or use the extract-text-webpack-plugin to
extract the style from the js. Neither of these steps is needed but
they provide avenues for the browser to stand the page up faster.